### PR TITLE
Prevent include role from gobbling up newline before it.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **.swp
+/vendor/

--- a/Parser.php
+++ b/Parser.php
@@ -734,7 +734,7 @@ class Parser
         $environment = $this->getEnvironment();
         $parser = $this;
 
-        return preg_replace_callback('/\n\.\. include:: (.+)\n/', function($match) use ($parser, $environment) {
+        return preg_replace_callback('/^\.\. include:: (.+)$/m', function($match) use ($parser, $environment) {
             $path = $environment->absoluteRelativePath($match[1]);
             return $parser->includeFiles(file_get_contents($path));
         }, $document);

--- a/tests/ParserTests.php
+++ b/tests/ParserTests.php
@@ -1,5 +1,6 @@
 <?php
 
+use Gregwar\RST\Nodes\Node;
 use Gregwar\RST\Parser;
 use Gregwar\RST\Document;
 
@@ -250,6 +251,19 @@ class ParserTests extends \PHPUnit_Framework_TestCase
             $this->assertTrue($options['titlesonly']);
             $this->assertEquals(123, $options['maxdepth']);
         }
+    }
+
+    public function testNewlineBeforeAnIncludedIsntGobbled()
+    {
+        /** @var Node[] $nodes */
+        $nodes = $this->parse('inclusion-newline.rst')->getNodes();
+
+        $this->assertCount(3, $nodes);
+        $this->assertInstanceOf('Gregwar\RST\Nodes\TitleNode', $nodes[0]);
+        $this->assertInstanceOf('Gregwar\RST\Nodes\ParagraphNode', $nodes[1]);
+        $this->assertInstanceOf('Gregwar\RST\Nodes\ParagraphNode', $nodes[2]);
+        $this->assertContains('<p>Test this paragraph is present.</p>', $nodes[1]->render());
+        $this->assertContains('<p>And this one as well.</p>', $nodes[2]->render());
     }
 
     /**

--- a/tests/files/inclusion-newline-include.rst
+++ b/tests/files/inclusion-newline-include.rst
@@ -1,0 +1,1 @@
+And this one as well.

--- a/tests/files/inclusion-newline.rst
+++ b/tests/files/inclusion-newline.rst
@@ -1,0 +1,6 @@
+Inclusion test
+==============
+
+Test this paragraph is present.
+
+.. include:: inclusion-newline-include.rst

--- a/tests/files/inclusion.rst
+++ b/tests/files/inclusion.rst
@@ -3,5 +3,3 @@ Inclusion test
 ==============
 
 .. include:: include.rst
-
-


### PR DESCRIPTION
Before, there would only be one paragraph in the document.