### PR TITLE
Reduce eagerness of literal matching

### DIFF
--- a/Span.php
+++ b/Span.php
@@ -26,7 +26,7 @@ abstract class Span extends Node
         
         // Replacing literal with tokens
         $tokens = array();
-        $span = preg_replace_callback('/``(.+)``/mUsi', function($match) use (&$tokens, $generator) {
+        $span = preg_replace_callback('/``(.+)``(?!`)/mUsi', function($match) use (&$tokens, $generator) {
             $id = $generator();
             $tokens[$id] = array(
                 'type' => 'literal',

--- a/tests/HTMLTests.php
+++ b/tests/HTMLTests.php
@@ -387,6 +387,17 @@ class HTMLTests extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, substr_count($document, 'unresolved'));
     }
 
+    public function testReferenceMatchingIsntTooEager()
+    {
+        // Before, it would render
+        // <p><code>:doc:`lorem</code><a href="https://consectetur.org"> and 249a92befe90adcd3bb404a91d4e1520a17a8b56` sit `amet</a></p>
+
+        $this->assertSame(
+            "<p><code>:doc:`lorem`</code> and <code>:code:`what`</code> sit <a href=\"https://consectetur.org\">amet</a></p>\n",
+            $this->parse('no-eager-literals.rst')->render()
+        );
+    }
+
     public function testUnknownDirective()
     {
         try {

--- a/tests/html/no-eager-literals.rst
+++ b/tests/html/no-eager-literals.rst
@@ -1,0 +1,1 @@
+``:doc:`lorem``` and ``:code:`what``` sit `amet <https://consectetur.org>`_


### PR DESCRIPTION
Before,

```
``:doc:`lorem``` and ``:code:`what``` sit `amet <https://consectetur.org>`_
```

... would render as:

<p><code>:doc:`lorem</code><a href="https://consectetur.org"> and 249a92befe90adcd3bb404a91d4e1520a17a8b56` sit `amet</a></p>

... after this fix:

<p><code>:doc:`lorem`</code> and <code>:code:`what`</code> sit <a href="https://consectetur.org">amet</a></p>