### PR TITLE
Fixing `Notice: Undefined index: titles`

### DIFF
--- a/References/Doc.php
+++ b/References/Doc.php
@@ -29,8 +29,9 @@ class Doc extends Reference
             $entry['url'] = $environment->relativeUrl('/'.$entry['url']);
         } else {
             $entry = array(
-                'title' => '(unresolved)',
-                'url' => '#'
+                'title'  => '(unresolved)',
+                'titles' => array(),
+                'url'    => '#'
             );
         }
 


### PR DESCRIPTION
In some cases, a PHP notice is returned because the array key `titles` doesn't exists like:

```bash
Error: Method Gregwar\RST\HTML\Document::__toString() must not throw an exception, caught ErrorException: Notice: Undefined index: titles
```

Fixing this issue by returning an empty array.