### PR TITLE
Add 'code' as alternative to 'code-block'.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-    - 5.3
     - 5.4
     - 5.5
     - 5.6

--- a/Directives/Code.php
+++ b/Directives/Code.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Gregwar\RST\Directives;
+
+use Gregwar\RST\Parser;
+use Gregwar\RST\Directive;
+
+use Gregwar\RST\Nodes\WrapperNode;
+use Gregwar\RST\Nodes\CodeNode;
+
+/**
+ * Renders a code block, example:
+ *
+ * .. code:: php
+ *
+ *      <?php
+ *
+ *      echo "Hello world!\n";
+ */
+class Code extends Directive
+{
+    public function getName()
+    {
+        return 'code';
+    }
+
+    public function process(Parser $parser, $node, $variable, $data, array $options)
+    {
+        if ($node) {
+            $kernel = $parser->getKernel();
+
+            if ($node instanceof CodeNode) {
+                $node->setLanguage(trim($data));
+            }
+
+            if ($variable) {
+                $environment = $parser->getEnvironment();
+                $environment->setVariable($variable, $node);
+            } else {
+                $document = $parser->getDocument();
+                $document->addNode($node);
+            }
+        }
+    }
+
+    public function wantCode()
+    {
+        return true;
+    }
+}

--- a/Kernel.php
+++ b/Kernel.php
@@ -41,6 +41,7 @@ abstract class Kernel
     {
         return array(
             new Directives\Dummy,
+            new Directives\Code,
             new Directives\CodeBlock,
             new Directives\Raw,
             new Directives\Replace,


### PR DESCRIPTION
I have seen several RST markdown files where 'code::' is used instead of 'code-block::'. This causes the library to throw an error about 'unknown directive'. So simply copy Directives/CodeBlock.php to Directives/Code.php and add Directives\Code to Kernel.php to allow ignorant users to use 'code:'', even if it is incorrect.