### PR TITLE
Do not treat paragraphs starting with 0 as blockquote

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ php:
 
 script:
     - composer install
-    - phpunit
+    - vendor/bin/phpunit

--- a/HTML/Nodes/ParagraphNode.php
+++ b/HTML/Nodes/ParagraphNode.php
@@ -10,7 +10,7 @@ class ParagraphNode extends Base
     {
         $text = $this->value;
 
-        if (trim($text)) {
+        if (trim($text) !== '') {
             return '<p>'.$text.'</p>';
         } else {
             return '';

--- a/LaTeX/Nodes/ParagraphNode.php
+++ b/LaTeX/Nodes/ParagraphNode.php
@@ -10,7 +10,7 @@ class ParagraphNode extends Base
     {
         $text = $this->value;
 
-        if (trim($text)) {
+        if (trim($text) !== '') {
             return $text."\n";
         } else {
             return '';

--- a/Parser.php
+++ b/Parser.php
@@ -391,7 +391,7 @@ class Parser
      */
     public function pushListLine($line, $flush = false)
     {
-        if (trim($line)) {
+        if (trim($line) !== '') {
             $infos = $this->parseListLine($line);
 
             if ($infos) {
@@ -440,9 +440,9 @@ class Parser
     protected function isBlockLine($line)
     {
         if (strlen($line)) {
-            return !trim($line[0]);
+            return trim($line[0]) === '';
         } else {
-            return !trim($line);
+            return trim($line) === '';
         }
     }
 
@@ -662,7 +662,7 @@ class Parser
             break;
 
         case self::STATE_TABLE:
-            if (!trim($line)) {
+            if (trim($line) === '') {
                 $this->flush();
                 $this->state = self::STATE_BEGIN;
             } else {
@@ -716,7 +716,7 @@ class Parser
         case self::STATE_COMMENT:
             $isComment = false;
 
-            if (!$this->isComment($line) && (!trim($line) || $line[0] != ' ')) {
+            if (!$this->isComment($line) && (trim($line) === '' || $line[0] != ' ')) {
                 $this->state = self::STATE_BEGIN;
                 return false;
             }

--- a/tests/ParserTests.php
+++ b/tests/ParserTests.php
@@ -85,10 +85,16 @@ class ParserTests extends \PHPUnit\Framework\TestCase
     public function testParagraphNodes()
     {
         $document = $this->parse('paragraphs.rst');
+
+        $this->assertNotHasNode($document, function($node) {
+            return $node instanceof QuoteNode;
+        });
         
         $this->assertHasNode($document, function($node) {
             return $node instanceof ParagraphNode;
-        }, 3);
+        }, 4);
+
+        $this->assertContains('0 started', $document->render());
     }
 
     /**

--- a/tests/files/paragraphs.rst
+++ b/tests/files/paragraphs.rst
@@ -6,3 +6,4 @@ With two lines
 Paragraph 3
 With *emphasis*
 
+0 started to test php casting issues


### PR DESCRIPTION
0 was treated trimable because the result of trim('0') – which is '0' – evaluates to false.
Fix that by using (strict) string comparison.

Also add a test that ensures a trailing zero is not interpreted as quote.