### PR TITLE
Fixed false deprecation

### DIFF
--- a/Directive.php
+++ b/Directive.php
@@ -32,7 +32,7 @@ abstract class Directive
      * @param $node the node that follows the directive
      * @param $variable the variable name of the directive
      * @param $data the data of the directive (following ::)
-     * @param $ptions the array of options for this directive
+     * @param $options the array of options for this directive
      */
     public function process(Parser $parser, $node, $variable, $data, array $options)
     {


### PR DESCRIPTION
Lately, I was making a small bundle for fun, and I across this warning on PHP 7.4.

**Warning:**
```
User Deprecated: The "Gregwar\RST\Directives\CodeBlock::process()" method will require a new "$ptions" argument in the next major version of its parent class "Gregwar\RST\Directive", not defining it is deprecated.
```

![image](https://user-images.githubusercontent.com/3246162/78841493-c1015c00-79fd-11ea-861b-32078de43b3a.png)
