### PR TITLE
Adding line number support for BlockNodes.

### DIFF
--- a/Nodes/BlockNode.php
+++ b/Nodes/BlockNode.php
@@ -4,6 +4,8 @@ namespace Gregwar\RST\Nodes;
 
 abstract class BlockNode extends Node
 {
+    private $startingLineNumber = 0;
+
     public function __construct(array $lines)
     {
         if (count($lines)) {
@@ -20,5 +22,15 @@ abstract class BlockNode extends Node
         }
 
         $this->value = implode("\n", $lines);
+    }
+
+    public function setStartingLineNumber($startingLineNumber)
+    {
+        $this->startingLineNumber = $startingLineNumber;
+    }
+
+    public function getStartingLineNumber()
+    {
+        return $this->startingLineNumber;
     }
 }

--- a/Parser.php
+++ b/Parser.php
@@ -2,6 +2,8 @@
 
 namespace Gregwar\RST;
 
+use Gregwar\RST\Nodes\BlockNode;
+
 class Parser
 {
     const STATE_BEGIN = 0;
@@ -583,6 +585,11 @@ class Parser
                 $this->isCode = $this->prepareCode();
                 $node = $this->kernel->build('Nodes\ParagraphNode', $this->createSpan($this->buffer));
                 break;
+            }
+
+            if ($node instanceof BlockNode) {
+                // We need to subtract one here because the last line of the buffer is an empty line
+                $node->setStartingLineNumber($this->currentLine - count($this->buffer) - 1);
             }
         }
 


### PR DESCRIPTION
For block nodes it makes sense to track the line number in the original document.

This is a feature I need in one of my projects because I am using this library just for parsing the nodes and processing. There it would be helpful if this library would support tracking line number of the nodes it parsed.

If you don't want this feature just let me know and I will maintain a fork for it.